### PR TITLE
Change: abbreviate the file name in the created record

### DIFF
--- a/README.org
+++ b/README.org
@@ -29,6 +29,10 @@ You can also customize the variable =org-bookmark-jump-indirect= to make Org boo
 
 * Changelog
 
+** 1.4-pre
+
+Nothing new yet.
+
 ** 1.3.1
 
 *Fixes*

--- a/README.org
+++ b/README.org
@@ -31,7 +31,9 @@ You can also customize the variable =org-bookmark-jump-indirect= to make Org boo
 
 ** 1.4-pre
 
-Nothing new yet.
+*Changes*
+
++ Abbreviate filenames with ~abbreviate-file-name~.  ([[https://github.com/alphapapa/org-bookmark-heading/pull/9][#9]].  Thanks to [[https://github.com/akirak][Akira Komamura]].)
 
 ** 1.3.1
 

--- a/org-bookmark-heading.el
+++ b/org-bookmark-heading.el
@@ -1,7 +1,7 @@
 ;;; org-bookmark-heading.el --- Emacs bookmark support for Org mode  -*- lexical-binding: t; -*-
 
 ;; Author: Adam Porter <adam@alphapapa.net>
-;; Version: 1.3.1
+;; Version: 1.4-pre
 ;; Url: http://github.com/alphapapa/org-bookmark-heading
 ;; Package-Requires: ((emacs "24.4"))
 ;; Keywords: hypermedia, outlines

--- a/org-bookmark-heading.el
+++ b/org-bookmark-heading.el
@@ -120,7 +120,7 @@ Called with point on heading.  Can be used to, e.g. cycle visibility."
 (defun org-bookmark-heading-make-record ()
   "Return bookmark record for current heading.
 Sets ID property for heading if necessary."
-  (let* ((filename (buffer-file-name (org-base-buffer (current-buffer))))
+  (let* ((filename (abbreviate-file-name (buffer-file-name (org-base-buffer (current-buffer)))))
          (display-filename (funcall org-bookmark-heading-filename-fn filename))
          (heading (unless (org-before-first-heading-p)
                     (org-link-display-format (org-get-heading t t))))


### PR DESCRIPTION
For the same reason as in alphapapa/org-ql#208, file names should be abbreviated in bookmarks.