### PR TITLE
Fix: org-bookmark-heading.el byte compilation

### DIFF
--- a/org-bookmark-heading.el
+++ b/org-bookmark-heading.el
@@ -62,6 +62,7 @@
 (require 'mode-local)
 (require 'org)
 (require 'bookmark)
+(require 'map)
 
 ;;;; Customization
 


### PR DESCRIPTION
`(require 'map)` is needed for `(pcase-let*)` `(map ...)` pattern.