### PR TITLE
Restore automatic suppression of ID creation during org-refile and org-capture

### DIFF
--- a/org-bookmark-heading.el
+++ b/org-bookmark-heading.el
@@ -3,7 +3,7 @@
 ;; Author: Adam Porter <adam@alphapapa.net>
 ;; Version: 1.4-pre
 ;; Url: http://github.com/alphapapa/org-bookmark-heading
-;; Package-Requires: ((emacs "24.4"))
+;; Package-Requires: ((emacs "26.1"))
 ;; Keywords: hypermedia, outlines
 
 ;;; Commentary:

--- a/org-bookmark-heading.el
+++ b/org-bookmark-heading.el
@@ -114,6 +114,9 @@ Called with point on heading.  Can be used to, e.g. cycle visibility."
 
 (setq-mode-local org-mode bookmark-make-record-function 'org-bookmark-heading-make-record)
 
+(setq org-bookmark-heading--refile-in-progress nil)
+(setq org-bookmark-heading--store-in-progress nil)
+
 ;;;; Functions
 
 ;;;###autoload
@@ -129,28 +132,22 @@ Sets ID property for heading if necessary."
          (outline-path (when heading
                          (org-get-outline-path 'with-self)))
          (indirectp (when (buffer-base-buffer) t))
-         id handler)
-    (unless (and (boundp 'bookmark-name)
-                 (or (string= bookmark-name (plist-get org-bookmark-names-plist :last-capture-marker))
-                     (string= bookmark-name (plist-get org-bookmark-names-plist :last-capture))
-                     (string= bookmark-name (plist-get org-bookmark-names-plist :last-refile))))
+
+         (handler #'org-bookmark-heading-jump)
+         id)
+    (unless (or org-bookmark-heading--refile-in-progress org-bookmark-heading--store-in-progress)
       ;; When `org-capture-mode' is active, and/or when a heading is
-      ;; being refiled, do not create an org-id for the current
-      ;; heading, and do not set the bookmark handler.  This is
+      ;; being refiled, do not create an org-id for the current heading. This is
       ;; because org-capture sets a bookmark for the last capture when
       ;; `org-capture-bookmark' is non-nil, and `org-refile' sets a
       ;; bookmark when a heading is refiled, and we don't want every
       ;; heading captured or refiled to get an org-id set by this
       ;; function, because not everyone wants to have property drawers
-      ;; "polluting" every heading in their org files. `bookmark-name'
-      ;; is set in `org-capture-bookmark-last-stored-position' and in
-      ;; `org-refile', and it seems to be the way to detect whether
-      ;; this is being called from a capture or a refile.
+      ;; "polluting" every heading in their org files.
       (setf id (org-id-get (point) (pcase-exhaustive org-bookmark-heading-make-ids
                                      (`t t)
                                      (`nil nil)
-                                     ((pred functionp) (funcall org-bookmark-heading-make-ids))))
-            handler #'org-bookmark-heading-jump))
+                                     ((pred functionp) (funcall org-bookmark-heading-make-ids))))))
     (rassq-delete-all nil `(,name
                             (filename . ,filename)
                             (handler . ,handler)
@@ -271,6 +268,18 @@ better way to do this, but Helm can be confusing, and this works."
   (add-to-list 'helm-type-bookmark-actions
                '("Jump to org-mode bookmark in indirect buffer" . helm-org-bookmark-jump-indirect-action)
                t))
+
+;;;; Help detect the 'org-refile' and 'org-capture-store-last-position' cases by toggling flags
+
+(defun org-bookmark-heading--before-refile (&rest _args) (setq org-bookmark-heading--refile-in-progress t))
+(defun org-bookmark-heading--after-refile (&rest _args) (setq org-bookmark-heading--refile-in-progress nil))
+(defun org-bookmark-heading--before-store (&rest _args) (setq org-bookmark-heading--store-in-progress t))
+(defun org-bookmark-heading--after-store (&rest _args) (setq org-bookmark-heading--store-in-progress nil))
+
+(advice-add 'org-refile :before 'org-bookmark-heading--before-refile)
+(advice-add 'org-refile :after 'org-bookmark-heading--after-refile)
+(advice-add 'org-capture-store-last-position :before 'org-bookmark-heading--before-store)
+(advice-add 'org-capture-store-last-position :after 'org-bookmark-heading--after-store)
 
 ;;;; Footer
 


### PR DESCRIPTION
_(This description contains the same information as the commit messages, with added formatting)_

This PR contains 3 changes:

(1) Restore the previous behaviour of avoiding ID creation during `org-refile` and `org-capture` calls in the `org-bookmark-heading-make-record` function, by updating the detection mechanism in response to upstream org-mode changes.

The previous mechanism (added in 2018) checked for the `bookmark-name` variable being bound to certain values, but bookmark-name is no longer visible to this package, confirmed by debugging with edebug: `(boundp 'bookmark-name)` always returns `nil`.
The `org-refile.el` file was added upstream in 2020, with lexical binding, as a potential cause.

The new mechanism detects org-refile and org-capture calls using flags, which are toggled before and after the upstream calls from `org-refile` and `org-capture-store-last-position`.

The flags are intentionally set globally, beyond org-mode, as calls like org-capture are initiated outside of org-mode.

(2) When making bookmark records, always set the handler, even if not setting the ID.

Without this change, these org-bookmark-heading style records with no handler field cause odd behaviour when jumping to their bookmarks.

(3) Raise minimum required Emacs version from 24.4 to 26.1.

Suggested by Elisp linting, due to referencing the `org-capture-store-last-position` function.

